### PR TITLE
refactor: switch to using DataLad Next's constraints

### DIFF
--- a/datalad_redcap/query.py
+++ b/datalad_redcap/query.py
@@ -6,18 +6,19 @@ from typing import Optional
 from prettytable import PrettyTable
 from redcap.methods.instruments import Instruments
 
-from datalad.interface.base import (
-    Interface,
-    build_doc,
-)
-from datalad.interface.results import get_status_dict
-from datalad.interface.utils import eval_results
-from datalad.support.constraints import (
-    EnsureStr,
-    EnsureChoice,
-)
-from datalad.support.param import Parameter
 from datalad.ui import ui
+from datalad_next.commands import (
+    EnsureCommandParameterization,
+    Parameter,
+    ValidatedInterface,
+    build_doc,
+    eval_results,
+    get_status_dict,
+)
+from datalad_next.constraints import (
+    EnsureStr,
+    EnsureURL,
+)
 from datalad_next.utils import CredentialManager
 
 from .utils import update_credentials
@@ -54,7 +55,7 @@ class MyInstruments(Instruments):
 
 
 @build_doc
-class Query(Interface):
+class Query(ValidatedInterface):
     """Query REDCap's API for available instruments (data entry forms)
 
     Can be used to retrieve human-oriented labels and API-oriented names of
@@ -71,7 +72,6 @@ class Query(Interface):
         url=Parameter(
             args=("url",),
             doc="API URL to a REDCap server",
-            constraints=EnsureStr(),
         ),
         credential=Parameter(
             args=("--credential",),
@@ -83,6 +83,13 @@ class Query(Interface):
             last-used credential matching the API url will be used if
             present; otherwise the user will be prompted and the
             credential will be saved under a default name.""",
+        ),
+    )
+
+    _validator_ = EnsureCommandParameterization(
+        dict(
+            url=EnsureURL(required=["scheme", "netloc", "path"]),
+            credential=EnsureStr(),
         ),
     )
 


### PR DESCRIPTION
This changes the constraint declaration for parameters to the method introduced in DataLad Next.

The most visible change is that we introduce EnsureURL, in which we require that that the API URL has scheme (e.g. `https`), netloc (e.g. `www.example.com`) and path (e.g. `/api/`). This seems reasonable, considering that PyCap complains even if the url ends with `/api` and not `/api/`.

One thing that will probably change soon is that currently we need to act differently if the dataset parameter is None, see https://github.com/datalad/datalad-next/issues/225

Closes #5