### PR TITLE
Add remaining tests

### DIFF
--- a/datalad_redcap/tests/test_export_form.py
+++ b/datalad_redcap/tests/test_export_form.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+
+from datalad.api import export_redcap_form
+from datalad.distribution.dataset import Dataset
+from datalad_next.tests.utils import (
+    assert_status,
+    eq_,
+    with_credential,
+    with_tempfile,
+)
+
+TEST_TOKEN = "WTJ3G8XWO9G8V1BB4K8N81KNGRPFJOVL"  # needed to pass length assertion
+CSV_CONTENT = "foo,bar,baz\nspam,spam,spam"
+CREDNAME = "redcap"
+
+
+@with_tempfile
+@patch("datalad_redcap.export_form.Records.export_records", return_value=CSV_CONTENT)
+@with_credential(CREDNAME, type="token", secret=TEST_TOKEN)
+def test_export_writes_file(ds_path=None, mocker=None):
+    ds = Dataset(ds_path).create(result_renderer="disabled")
+    fname = "form.csv"
+
+    res = export_redcap_form(
+        url="https://www.example.com/api/",
+        forms=["foo"],
+        outfile=fname,
+        dataset=ds,
+        credential=CREDNAME,
+    )
+
+    # check that the command returned ok
+    assert_status("ok", res)
+
+    # check that the file was created and left in clean state
+    eq_(ds.status(fname, return_type="item-or-list").get("state"), "clean")

--- a/datalad_redcap/tests/test_export_form.py
+++ b/datalad_redcap/tests/test_export_form.py
@@ -9,14 +9,14 @@ from datalad_next.tests.utils import (
     with_tempfile,
 )
 
-TEST_TOKEN = "WTJ3G8XWO9G8V1BB4K8N81KNGRPFJOVL"  # needed to pass length assertion
+DUMMY_TOKEN = "WTJ3G8XWO9G8V1BB4K8N81KNGRPFJOVL"  # needed to pass length assertion
 CSV_CONTENT = "foo,bar,baz\nspam,spam,spam"
 CREDNAME = "redcap"
 
 
 @with_tempfile
 @patch("datalad_redcap.export_form.Records.export_records", return_value=CSV_CONTENT)
-@with_credential(CREDNAME, type="token", secret=TEST_TOKEN)
+@with_credential(CREDNAME, type="token", secret=DUMMY_TOKEN)
 def test_export_writes_file(ds_path=None, mocker=None):
     ds = Dataset(ds_path).create(result_renderer="disabled")
     fname = "form.csv"

--- a/datalad_redcap/tests/test_parameters.py
+++ b/datalad_redcap/tests/test_parameters.py
@@ -19,14 +19,14 @@ from datalad_next.tests.utils import (
 )
 from datalad_next.utils import chpwd
 
-TEST_TOKEN = "WTJ3G8XWO9G8V1BB4K8N81KNGRPFJOVL"  # needed to pass length assertion
+DUMMY_TOKEN = "WTJ3G8XWO9G8V1BB4K8N81KNGRPFJOVL"  # needed to pass length assertion
 CSV_CONTENT = "foo,bar,baz\nspam,spam,spam"
 CREDNAME = "redcap"
 
 
 @with_tempfile
 @patch("datalad_redcap.export_form.Records.export_records", return_value=CSV_CONTENT)
-@with_credential(CREDNAME, type="token", secret=TEST_TOKEN)
+@with_credential(CREDNAME, type="token", secret=DUMMY_TOKEN)
 def test_url_rejected(ds_path=None, mocker=None):
     """Test that bad-form urls are rejected by validation"""
     ds = Dataset(ds_path).create(result_renderer="disabled")
@@ -41,7 +41,7 @@ def test_url_rejected(ds_path=None, mocker=None):
 
 
 @with_tempfile
-@with_credential(CREDNAME, type="token", secret=TEST_TOKEN)
+@with_credential(CREDNAME, type="token", secret=DUMMY_TOKEN)
 @patch("datalad_redcap.export_form.Records.export_records", return_value=CSV_CONTENT)
 def test_dataset_not_found(path=None, mocker=None):
     """Test that nonexistent dataset is rejected by validation"""

--- a/datalad_redcap/tests/test_parameters.py
+++ b/datalad_redcap/tests/test_parameters.py
@@ -1,0 +1,67 @@
+"""Tests related to parameter handling
+
+These test for ValueError being raised in example situations related
+to parameter validation, and should help ensure that parameter
+validation works as expected. The export_records command is used as an
+example command, and we still mock the api calls to let the command
+run if validation doesn't complain.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from datalad.api import export_redcap_form
+from datalad.distribution.dataset import Dataset
+
+from datalad_next.tests.utils import (
+    with_credential,
+    with_tempfile,
+)
+from datalad_next.utils import chpwd
+
+TEST_TOKEN = "WTJ3G8XWO9G8V1BB4K8N81KNGRPFJOVL"  # needed to pass length assertion
+CSV_CONTENT = "foo,bar,baz\nspam,spam,spam"
+CREDNAME = "redcap"
+
+
+@with_tempfile
+@patch("datalad_redcap.export_form.Records.export_records", return_value=CSV_CONTENT)
+@with_credential(CREDNAME, type="token", secret=TEST_TOKEN)
+def test_url_rejected(ds_path=None, mocker=None):
+    """Test that bad-form urls are rejected by validation"""
+    ds = Dataset(ds_path).create(result_renderer="disabled")
+    with pytest.raises(ValueError):
+        export_redcap_form(
+            url="example.com",  # missing scheme, path
+            forms=["foo"],
+            outfile="foo.csv",
+            dataset=ds,
+            credential=CREDNAME,
+        )
+
+
+@with_tempfile
+@with_credential(CREDNAME, type="token", secret=TEST_TOKEN)
+@patch("datalad_redcap.export_form.Records.export_records", return_value=CSV_CONTENT)
+def test_dataset_not_found(path=None, mocker=None):
+    """Test that nonexistent dataset is rejected by validation"""
+
+    # explicit path that isn't a dataset
+    with pytest.raises(ValueError):
+        export_redcap_form(
+            url="https://example.com/api",
+            forms=["foo"],
+            outfile="foo",
+            dataset=path,
+            credential=CREDNAME,
+        )
+
+    # no path given, pwd is not a dataset
+    with chpwd(path, mkdir=True):
+        with pytest.raises(ValueError):
+            export_redcap_form(
+                url="https://example.com/api",
+                forms=["foo"],
+                outfile="foo",
+                credential=CREDNAME,
+            )

--- a/datalad_redcap/tests/test_query.py
+++ b/datalad_redcap/tests/test_query.py
@@ -1,0 +1,22 @@
+from unittest.mock import patch
+
+from datalad.api import redcap_query
+from datalad_next.tests.utils import (
+    assert_result_count,
+    with_credential,
+)
+
+DUMMY_URL = "https://www.example.com/api/"
+DUMMY_TOKEN = "WTJ3G8XWO9G8V1BB4K8N81KNGRPFJOVL"  # needed to pass length assertion
+JSON_CONTENT = {"foo": "bar"}
+CREDNAME = "redcap"
+
+
+@patch(
+    "datalad_redcap.query.MyInstruments.export_instruments", return_value=JSON_CONTENT
+)
+@with_credential(CREDNAME, type="token", secret=DUMMY_TOKEN)
+def test_redcap_query_has_result(mocker=None):
+    assert_result_count(
+        redcap_query(url=DUMMY_URL, credential=CREDNAME, result_renderer="disabled"), 1
+    )

--- a/datalad_redcap/tests/test_register.py
+++ b/datalad_redcap/tests/test_register.py
@@ -1,11 +1,6 @@
-from datalad.tests.utils_pytest import assert_result_count
-
-
 def test_register():
     import datalad.api as da
-    assert hasattr(da, 'export_redcap_form')
-    # assert_result_count(
-    #     da.hello_cmd(),
-    #     1,
-    #     action='demo')
 
+    assert hasattr(da, "export_redcap_form")
+    assert hasattr(da, "export_redcap_report")
+    assert hasattr(da, "redcap_query")

--- a/datalad_redcap/tests/test_utils.py
+++ b/datalad_redcap/tests/test_utils.py
@@ -5,6 +5,7 @@ from datalad_next.tests.utils import with_tempfile
 
 from datalad_redcap.utils import check_ok_to_edit
 
+
 @with_tempfile
 def test_check_ok_to_edit(path=None):
     """Tests whether location/state is correctly recognized"""

--- a/datalad_redcap/tests/test_utils.py
+++ b/datalad_redcap/tests/test_utils.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from datalad.distribution.dataset import Dataset
+from datalad_next.tests.utils import with_tempfile
+
+from datalad_redcap.utils import check_ok_to_edit
+
+@with_tempfile
+def test_check_ok_to_edit(path=None):
+    """Tests whether location/state is correctly recognized"""
+    basedir = Path(path)
+    ds = Dataset(basedir / "ds").create(result_renderer="disabled")
+    subds = ds.create("subds", result_renderer="disabled")
+
+    outside = basedir / "file_outside"
+    inside = basedir / "ds" / "ds_file"
+    below = basedir / "ds" / "subds" / "subds_file"
+
+    outside.write_text("dummy")
+    inside.write_text("dummy")
+    below.write_text("dummy")
+
+    ds.save(recursive=True)
+
+    # outside is not ok
+    ok2ed, _ = check_ok_to_edit(outside, ds)
+    assert not ok2ed
+
+    # inside is ok
+    ok2ed, _ = check_ok_to_edit(inside, ds)
+    assert ok2ed
+
+    # subdataset is not ok
+    ok2ed, _ = check_ok_to_edit(below, ds)
+    assert not ok2ed
+
+    # file with unsaved changes is not ok
+    ds.unlock(inside)
+    inside.write_text("new dummy")
+    ok2ed, _ = check_ok_to_edit(inside, ds)
+    assert not ok2ed


### PR DESCRIPTION
This introduces missing tests for the following:

- [x] export form
- [x] query
- [x] utils (at least `check_ok_to_edit`)
- [x] parameter validation

Once completed, will close #4 

See commit messages for details.