### PR TITLE
Docs and docs build update

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.9"
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .

--- a/README.md
+++ b/README.md
@@ -1,13 +1,28 @@
 # DataLad REDCap extension
 
-[![crippled-filesystems](https://github.com/datalad/datalad-redcap/workflows/crippled-filesystems/badge.svg)](https://github.com/datalad/datalad-redcap/actions/workflows/test_crippledfs.yml)
 [![docs](https://github.com/datalad/datalad-redcap/workflows/docs/badge.svg)](https://github.com/datalad/datalad-redcap/actions/workflows/docbuild.yml)
+
+[![crippled-filesystems](https://github.com/datalad/datalad-redcap/workflows/crippled-filesystems/badge.svg)](https://github.com/datalad/datalad-redcap/actions/workflows/test_crippledfs.yml)
 [![Documentation Status](https://readthedocs.org/projects/datalad-redcap/badge/?version=latest)](http://docs.datalad.org/projects/redcap/en/latest/?badge=latest)
 
 This DataLad extension provides convenience commands for exporting data from REDCap into DataLad datasets.
 Information about the RedCAP project can be found at https://project-redcap.org/.
 
 The extension is in early development.
+
+## Installation
+The extension has no official release yet, but you can install the *bleeding edge* version using pip, directly from GitHub.
+This will also install the latest development version of [DataLad Next](https://github.com/datalad/datalad-next) extension.
+Using a virtual environment is recommended.
+Example installation:
+
+```
+# create and enter a new virtual environment (optional)
+$ virtualenv --python=python3 ~/env/dl-redcap
+$ source ~/env/dl-redcap/bin/activate
+# install from GitHub main branch
+$ python -m pip install git+https://github.com/datalad/datalad-redcap.git@main
+```
 
 ## Commands
 - `export-redcap-form`: Export records from selected forms (instruments)


### PR DESCRIPTION
This should resolve an issue with Read the Docs builds where Python
API and CLI pages were not built - inspection of RtD build logs showed
that build_manpage & autosummary had ImportErrors, which were
converted to a warning. RtD build used Python 3.7.

Going up to Python 3.9 seems to be a sensible choice because that's
the current version in debian stable (although minimal requirement for
the extension is 3.8).

Important note: our docs build relies on having this package
installed. This apparently happened by default previously, but now
that we use the `.readthedocs.yaml` file, we have to state it
explicitly:

``` yaml
python:
  install:
    - method: pip
      path: .
```