### PR TITLE
test: switch from decorators to fixtures

### DIFF
--- a/datalad_redcap/conftest.py
+++ b/datalad_redcap/conftest.py
@@ -1,1 +1,29 @@
+import pytest
+
 from datalad.conftest import setup_package
+from datalad_next.credman import CredentialManager
+
+
+@pytest.fixture
+def api_url():
+    """Yield a dummy API URL that passes assertions"""
+    yield "https://www.example.com/api/"
+
+
+@pytest.fixture
+def credman_filled(api_url):
+    """Yield a credential manager containing a dummy token
+
+    The dummy token has the api_url as realm, allowing tests using the
+    api_url fixture to implictitly have a valid credential. The token
+    is 32 characters long to pass PyCap's assertion.
+    """
+    credman = CredentialManager()
+    credman.set(
+        name="pytest-redcap",
+        type="token",
+        secret="WTJ3G8XWO9G8V1BB4K8N81KNGRPFJOVL",
+        realm=api_url,
+    )
+    yield credman
+    credman.remove(name="pytest-redcap")

--- a/datalad_redcap/tests/test_export_form.py
+++ b/datalad_redcap/tests/test_export_form.py
@@ -5,29 +5,24 @@ from datalad.distribution.dataset import Dataset
 from datalad_next.tests.utils import (
     assert_status,
     eq_,
-    with_credential,
-    with_tempfile,
 )
 
-DUMMY_TOKEN = "WTJ3G8XWO9G8V1BB4K8N81KNGRPFJOVL"  # needed to pass length assertion
 CSV_CONTENT = "foo,bar,baz\nspam,spam,spam"
-CREDNAME = "redcap"
 
 
-@with_tempfile
-@patch("datalad_redcap.export_form.Records.export_records", return_value=CSV_CONTENT)
-@with_credential(CREDNAME, type="token", secret=DUMMY_TOKEN)
-def test_export_writes_file(ds_path=None, mocker=None):
-    ds = Dataset(ds_path).create(result_renderer="disabled")
+def test_export_writes_file(tmp_path, api_url, credman_filled):
+    ds = Dataset(tmp_path).create(result_renderer="disabled")
     fname = "form.csv"
 
-    res = export_redcap_form(
-        url="https://www.example.com/api/",
-        forms=["foo"],
-        outfile=fname,
-        dataset=ds,
-        credential=CREDNAME,
-    )
+    with patch(
+        "datalad_redcap.export_form.Records.export_records", return_value=CSV_CONTENT
+    ):
+        res = export_redcap_form(
+            url=api_url,
+            forms=["foo"],
+            outfile=fname,
+            dataset=ds,
+        )
 
     # check that the command returned ok
     assert_status("ok", res)

--- a/datalad_redcap/tests/test_export_project_xml.py
+++ b/datalad_redcap/tests/test_export_project_xml.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from unittest.mock import patch
 
 from datalad.api import export_redcap_project_xml
@@ -6,34 +5,26 @@ from datalad.distribution.dataset import Dataset
 from datalad_next.tests.utils import (
     assert_status,
     eq_,
-    with_credential,
-    with_tempfile,
 )
 from datalad.tests.utils_pytest import ok_file_has_content
 
-DUMMY_URL = "https://www.example.com/api/"
-DUMMY_TOKEN = "WTJ3G8XWO9G8V1BB4K8N81KNGRPFJOVL"  # needed to pass length assertion
 XML_CONTENT = """<?xml version="1.0" encoding="UTF-8" ?>"""
-CREDNAME = "redcap"
 
 
-@with_tempfile
-@patch(
-    "datalad_redcap.export_project_xml.ProjectInfo.export_project_xml",
-    return_value=XML_CONTENT,
-)
-@with_credential(CREDNAME, type="token", secret=DUMMY_TOKEN)
-def test_export_xml_saves_content(ds_path=None, mocker=None):
-    ds = Dataset(ds_path).create(result_renderer="disabled")
+def test_export_xml_saves_content(tmp_path, api_url, credman_filled):
+    ds = Dataset(tmp_path).create(result_renderer="disabled")
     fname = "project.xml"
 
-    res = export_redcap_project_xml(
-        url=DUMMY_URL,
-        outfile=fname,
-        dataset=ds,
-        credential=CREDNAME,
-    )
+    with patch(
+        "datalad_redcap.export_project_xml.ProjectInfo.export_project_xml",
+        return_value=XML_CONTENT,
+    ):
+        res = export_redcap_project_xml(
+            url=api_url,
+            outfile=fname,
+            dataset=ds,
+        )
 
     assert_status("ok", res)
-    ok_file_has_content(Path(ds_path).joinpath(fname), XML_CONTENT)
+    ok_file_has_content(tmp_path.joinpath(fname), XML_CONTENT)
     eq_(ds.status(fname, return_type="item-or-list").get("state"), "clean")

--- a/datalad_redcap/tests/test_export_report.py
+++ b/datalad_redcap/tests/test_export_report.py
@@ -5,29 +5,24 @@ from datalad.distribution.dataset import Dataset
 from datalad_next.tests.utils import (
     assert_status,
     eq_,
-    with_credential,
-    with_tempfile,
 )
 
-TEST_TOKEN = "WTJ3G8XWO9G8V1BB4K8N81KNGRPFJOVL"  # needed to pass length assertion
 CSV_CONTENT = "foo,bar,baz\nspam,spam,spam"
-CREDNAME = "redcap"
 
 
-@with_tempfile
-@patch("datalad_redcap.export_report.Reports.export_report", return_value=CSV_CONTENT)
-@with_credential(CREDNAME, type="token", secret=TEST_TOKEN)
-def test_export_writes_file(ds_path=None, mocker=None):
-    ds = Dataset(ds_path).create(result_renderer="disabled")
+def test_export_writes_file(tmp_path, api_url, credman_filled):
+    ds = Dataset(tmp_path).create(result_renderer="disabled")
     fname = "report.csv"
 
-    res = export_redcap_report(
-        url="https://www.example.com/api/",
-        report="1234",
-        outfile=fname,
-        dataset=ds,
-        credential=CREDNAME,
-    )
+    with patch(
+        "datalad_redcap.export_report.Reports.export_report", return_value=CSV_CONTENT
+    ):
+        res = export_redcap_report(
+            url=api_url,
+            report="1234",
+            outfile=fname,
+            dataset=ds,
+        )
 
     # check that the command returned ok
     assert_status("ok", res)

--- a/datalad_redcap/tests/test_parameters.py
+++ b/datalad_redcap/tests/test_parameters.py
@@ -3,8 +3,8 @@
 These test for ValueError being raised in example situations related
 to parameter validation, and should help ensure that parameter
 validation works as expected. The export_records command is used as an
-example command, and we still mock the api calls to let the command
-run if validation doesn't complain.
+example command, and we still mock the api calls and provide a dummy
+credential to let the command run if validation doesn't complain.
 """
 
 import pytest
@@ -13,55 +13,56 @@ from unittest.mock import patch
 from datalad.api import export_redcap_form
 from datalad.distribution.dataset import Dataset
 
-from datalad_next.tests.utils import (
-    with_credential,
-    with_tempfile,
-)
 from datalad_next.utils import chpwd
 
-DUMMY_TOKEN = "WTJ3G8XWO9G8V1BB4K8N81KNGRPFJOVL"  # needed to pass length assertion
 CSV_CONTENT = "foo,bar,baz\nspam,spam,spam"
-CREDNAME = "redcap"
 
 
-@with_tempfile
-@patch("datalad_redcap.export_form.Records.export_records", return_value=CSV_CONTENT)
-@with_credential(CREDNAME, type="token", secret=DUMMY_TOKEN)
-def test_url_rejected(ds_path=None, mocker=None):
+def test_url_rejected(tmp_path, credman_filled, api_url):
     """Test that bad-form urls are rejected by validation"""
-    ds = Dataset(ds_path).create(result_renderer="disabled")
+
+    credname, _ = credman_filled.query(realm=api_url)[0]
+    ds = Dataset(tmp_path).create(result_renderer="disabled")
+
     with pytest.raises(ValueError):
-        export_redcap_form(
-            url="example.com",  # missing scheme, path
-            forms=["foo"],
-            outfile="foo.csv",
-            dataset=ds,
-            credential=CREDNAME,
-        )
+        with patch(
+            "datalad_redcap.export_form.Records.export_records",
+            return_value=CSV_CONTENT,
+        ):
+            export_redcap_form(
+                url="example.com",  # missing scheme, path
+                forms=["foo"],
+                outfile="foo.csv",
+                dataset=ds,
+                credential=credname,
+            )
 
 
-@with_tempfile
-@with_credential(CREDNAME, type="token", secret=DUMMY_TOKEN)
-@patch("datalad_redcap.export_form.Records.export_records", return_value=CSV_CONTENT)
-def test_dataset_not_found(path=None, mocker=None):
+def test_dataset_not_found(tmp_path, credman_filled, api_url):
     """Test that nonexistent dataset is rejected by validation"""
 
     # explicit path that isn't a dataset
     with pytest.raises(ValueError):
-        export_redcap_form(
-            url="https://example.com/api",
-            forms=["foo"],
-            outfile="foo",
-            dataset=path,
-            credential=CREDNAME,
-        )
-
-    # no path given, pwd is not a dataset
-    with chpwd(path, mkdir=True):
-        with pytest.raises(ValueError):
+        with patch(
+            "datalad_redcap.export_form.Records.export_records",
+            return_value=CSV_CONTENT,
+        ):
             export_redcap_form(
-                url="https://example.com/api",
+                url=api_url,
                 forms=["foo"],
                 outfile="foo",
-                credential=CREDNAME,
+                dataset=tmp_path,
             )
+
+    # no path given, pwd is not a dataset
+    with chpwd(tmp_path, mkdir=True):
+        with pytest.raises(ValueError):
+            with patch(
+                "datalad_redcap.export_form.Records.export_records",
+                return_value=CSV_CONTENT,
+            ):
+                export_redcap_form(
+                    url=api_url,
+                    forms=["foo"],
+                    outfile="foo",
+                )

--- a/datalad_redcap/tests/test_query.py
+++ b/datalad_redcap/tests/test_query.py
@@ -6,17 +6,11 @@ from datalad_next.tests.utils import (
     with_credential,
 )
 
-DUMMY_URL = "https://www.example.com/api/"
-DUMMY_TOKEN = "WTJ3G8XWO9G8V1BB4K8N81KNGRPFJOVL"  # needed to pass length assertion
 JSON_CONTENT = {"foo": "bar"}
-CREDNAME = "redcap"
 
 
-@patch(
-    "datalad_redcap.query.MyInstruments.export_instruments", return_value=JSON_CONTENT
-)
-@with_credential(CREDNAME, type="token", secret=DUMMY_TOKEN)
-def test_redcap_query_has_result(mocker=None):
-    assert_result_count(
-        redcap_query(url=DUMMY_URL, credential=CREDNAME, result_renderer="disabled"), 1
-    )
+def test_redcap_query_has_result(credman_filled, api_url):
+    with patch("datalad_redcap.query.MyInstruments.export_instruments", return_value=JSON_CONTENT):
+        assert_result_count(
+            redcap_query(url=api_url, result_renderer="disabled"), 1
+        )

--- a/datalad_redcap/tests/test_register.py
+++ b/datalad_redcap/tests/test_register.py
@@ -3,4 +3,5 @@ def test_register():
 
     assert hasattr(da, "export_redcap_form")
     assert hasattr(da, "export_redcap_report")
+    assert hasattr(da, "export_redcap_project_xml")
     assert hasattr(da, "redcap_query")

--- a/datalad_redcap/tests/test_utils.py
+++ b/datalad_redcap/tests/test_utils.py
@@ -1,21 +1,16 @@
-from pathlib import Path
-
 from datalad.distribution.dataset import Dataset
-from datalad_next.tests.utils import with_tempfile
 
 from datalad_redcap.utils import check_ok_to_edit
 
 
-@with_tempfile
-def test_check_ok_to_edit(path=None):
+def test_check_ok_to_edit(tmp_path):
     """Tests whether location/state is correctly recognized"""
-    basedir = Path(path)
-    ds = Dataset(basedir / "ds").create(result_renderer="disabled")
+    ds = Dataset(tmp_path / "ds").create(result_renderer="disabled")
     subds = ds.create("subds", result_renderer="disabled")
 
-    outside = basedir / "file_outside"
-    inside = basedir / "ds" / "ds_file"
-    below = basedir / "ds" / "subds" / "subds_file"
+    outside = tmp_path / "file_outside"
+    inside = tmp_path / "ds" / "ds_file"
+    below = tmp_path / "ds" / "subds" / "subds_file"
 
     outside.write_text("dummy")
     inside.write_text("dummy")


### PR DESCRIPTION
This removes the use of with_tempfile and with_credential decorators
and introduces pytest fixtures instead. Two custom fixtures allow
tests to run with a credential manager that has a dummy token matching
a dummy realm, so tested commands can run with the implicit credential
lookup.

Because of fixtures, the use of unittest.mock.patch was changed from
decorator to context manager -- the decorator wants to supply the
first positional argument, so depending on argument order either the
decorator replaces the fixture or pytest complains about unknown
fixture. Or at least I couldn't make it work together. But in the end,
context manager also looks good.

Closes #20