### PR TITLE
Set DataLad-next 1.0.0b2 dependency, adjust accordingly

### DIFF
--- a/datalad_redcap/export_form.py
+++ b/datalad_redcap/export_form.py
@@ -173,7 +173,7 @@ class ExportForm(ValidatedInterface):
 
         # unlock the file if needed, and write contents
         if unlock:
-            ds.unlock(outfile)
+            yield from ds.unlock(outfile, result_renderer='disabled', return_type='generator')
         with open(outfile, "wt") as f:
             f.write(response)
 

--- a/datalad_redcap/export_form.py
+++ b/datalad_redcap/export_form.py
@@ -173,7 +173,9 @@ class ExportForm(ValidatedInterface):
 
         # unlock the file if needed, and write contents
         if unlock:
-            yield from ds.unlock(outfile, result_renderer='disabled', return_type='generator')
+            yield from ds.unlock(
+                outfile, result_renderer="disabled", return_type="generator"
+            )
         with open(outfile, "wt") as f:
             f.write(response)
 

--- a/datalad_redcap/export_form.py
+++ b/datalad_redcap/export_form.py
@@ -6,16 +6,10 @@ import textwrap
 from typing import (
     List,
     Optional,
-    Tuple,
 )
 
 from redcap.methods.records import Records
 
-from datalad.distribution.dataset import (
-    Dataset,
-    require_dataset,
-    resolve_path,
-)
 from datalad.interface.common_opts import (
     nosave_opt,
     save_message_opt,
@@ -35,9 +29,9 @@ from datalad_next.constraints import (
     EnsurePath,
     EnsureStr,
     EnsureURL,
+    DatasetParameter,
 )
 from datalad_next.constraints.dataset import (
-    DatasetParameter,
     EnsureDataset,
 )
 from datalad_next.utils import CredentialManager
@@ -115,6 +109,8 @@ class ExportForm(ValidatedInterface):
             message=EnsureStr(),
             save=EnsureBool(),
         ),
+        validate_defaults=("dataset",),
+        tailor_for_dataset=({"outfile": "dataset"}),
     )
 
     @staticmethod
@@ -131,18 +127,10 @@ class ExportForm(ValidatedInterface):
         save: bool = True,
     ):
 
-        # work with a dataset object
-        if dataset is None:
-            # https://github.com/datalad/datalad-next/issues/225
-            ds = require_dataset(None)
-        else:
-            ds = dataset.ds
-
-        # Sort out the path in context of the dataset
-        res_outfile = resolve_path(outfile, ds=ds)
+        ds = dataset.ds
 
         # refuse to operate if target file is outside the dataset or not clean
-        ok_to_edit, unlock = check_ok_to_edit(res_outfile, ds)
+        ok_to_edit, unlock = check_ok_to_edit(outfile, ds)
         if not ok_to_edit:
             yield get_status_dict(
                 action="export_redcap_form",
@@ -185,8 +173,8 @@ class ExportForm(ValidatedInterface):
 
         # unlock the file if needed, and write contents
         if unlock:
-            ds.unlock(res_outfile)
-        with open(res_outfile, "wt") as f:
+            ds.unlock(outfile)
+        with open(outfile, "wt") as f:
             f.write(response)
 
         # save changes in the dataset
@@ -195,7 +183,7 @@ class ExportForm(ValidatedInterface):
                 message=message
                 if message is not None
                 else _write_commit_message(forms),
-                path=res_outfile,
+                path=outfile,
             )
 
         # yield successful result if we made it to here

--- a/datalad_redcap/export_project_xml.py
+++ b/datalad_redcap/export_project_xml.py
@@ -207,7 +207,9 @@ class ExportProjectXML(ValidatedInterface):
 
         # unlock the file if needed, and write contents
         if unlock:
-            ds.unlock(outfile)
+            yield from ds.unlock(
+                outfile, result_renderer="disabled", return_type="generator"
+            )
         with open(outfile, "wt") as f:
             f.write(response)
 

--- a/datalad_redcap/export_project_xml.py
+++ b/datalad_redcap/export_project_xml.py
@@ -3,10 +3,6 @@ from typing import Optional
 
 from redcap.methods.project_info import ProjectInfo
 
-from datalad.distribution.dataset import (
-    require_dataset,
-    resolve_path,
-)
 from datalad.interface.common_opts import (
     nosave_opt,
     save_message_opt,
@@ -142,13 +138,15 @@ class ExportProjectXML(ValidatedInterface):
         dict(
             url=EnsureURL(required=["scheme", "netloc", "path"]),
             outfile=EnsurePath(),
-            dataset=EnsureDataset(installed=True, purpose="export redcap report"),
+            dataset=EnsureDataset(installed=True, purpose="export REDCap project XML"),
             credential=EnsureStr(),
             metadata_only=EnsureBool(),
             survey_fields=EnsureBool(),
             message=EnsureStr(),
             save=EnsureBool(),
         ),
+        validate_defaults=("dataset",),
+        tailor_for_dataset=({"outfile": "dataset"}),
     )
 
     @staticmethod
@@ -165,22 +163,14 @@ class ExportProjectXML(ValidatedInterface):
         save: bool = True,
     ):
 
-        # work with a dataset object
-        if dataset is None:
-            # https://github.com/datalad/datalad-next/issues/225
-            ds = require_dataset(None)
-        else:
-            ds = dataset.ds
-
-        # sort out the path in context of the dataset
-        res_outfile = resolve_path(outfile, ds=ds)
+        ds = dataset.ds
 
         # refuse to operate if target file is outside the dataset or not clean
-        ok_to_edit, unlock = check_ok_to_edit(res_outfile, ds)
+        ok_to_edit, unlock = check_ok_to_edit(outfile, ds)
         if not ok_to_edit:
             yield get_status_dict(
                 action="export_redcap_report",
-                path=res_outfile,
+                path=outfile,
                 status="error",
                 message=(
                     "Output file status is not clean or the file does not "
@@ -217,8 +207,8 @@ class ExportProjectXML(ValidatedInterface):
 
         # unlock the file if needed, and write contents
         if unlock:
-            ds.unlock(res_outfile)
-        with open(res_outfile, "wt") as f:
+            ds.unlock(outfile)
+        with open(outfile, "wt") as f:
             f.write(response)
 
         # save changes in the dataset
@@ -231,13 +221,13 @@ class ExportProjectXML(ValidatedInterface):
                     metadata_only=metadata_only,
                     survey_fields=survey_fields,
                 ),
-                path=res_outfile,
+                path=outfile,
             )
 
         # yield successful result if we made it to here
         yield get_status_dict(
             action="export_redcap_project_xml",
-            path=res_outfile,
+            path=outfile,
             status="ok",
         )
 

--- a/datalad_redcap/export_report.py
+++ b/datalad_redcap/export_report.py
@@ -3,10 +3,6 @@ from typing import Optional
 
 from redcap.methods.reports import Reports
 
-from datalad.distribution.dataset import (
-    require_dataset,
-    resolve_path,
-)
 from datalad.interface.common_opts import (
     nosave_opt,
     save_message_opt,
@@ -92,11 +88,13 @@ class ExportReport(ValidatedInterface):
             url=EnsureURL(required=["scheme", "netloc", "path"]),
             report=EnsureStr(),
             outfile=EnsurePath(),
-            dataset=EnsureDataset(installed=True, purpose="export redcap report"),
+            dataset=EnsureDataset(installed=True, purpose="export REDCap report"),
             credential=EnsureStr(),
             message=EnsureStr(),
             save=EnsureBool(),
-        )
+        ),
+        validate_defaults=("dataset",),
+        tailor_for_dataset=({"outfile": "dataset"}),
     )
 
     @staticmethod
@@ -112,22 +110,14 @@ class ExportReport(ValidatedInterface):
         save: bool = True,
     ):
 
-        # work with a dataset object
-        if dataset is None:
-            # https://github.com/datalad/datalad-next/issues/225
-            ds = require_dataset(None)
-        else:
-            ds = dataset.ds
-
-        # sort out the path in context of the dataset
-        res_outfile = resolve_path(outfile, ds=ds)
+        ds = dataset.ds
 
         # refuse to operate if target file is outside the dataset or not clean
-        ok_to_edit, unlock = check_ok_to_edit(res_outfile, ds)
+        ok_to_edit, unlock = check_ok_to_edit(outfile, ds)
         if not ok_to_edit:
             yield get_status_dict(
                 action="export_redcap_report",
-                path=res_outfile,
+                path=outfile,
                 status="error",
                 message=(
                     "Output file status is not clean or the file does not "
@@ -163,20 +153,20 @@ class ExportReport(ValidatedInterface):
 
         # unlock the file if needed, and write contents
         if unlock:
-            ds.unlock(res_outfile)
-        with open(res_outfile, "wt") as f:
+            ds.unlock(outfile)
+        with open(outfile, "wt") as f:
             f.write(response)
 
         # save changes in the dataset
         if save:
             ds.save(
                 message=message if message is not None else "Export REDCap report",
-                path=res_outfile,
+                path=outfile,
             )
 
         # yield successful result if we made it to here
         yield get_status_dict(
             action="export_redcap_report",
-            path=res_outfile,
+            path=outfile,
             status="ok",
         )

--- a/datalad_redcap/export_report.py
+++ b/datalad_redcap/export_report.py
@@ -153,7 +153,9 @@ class ExportReport(ValidatedInterface):
 
         # unlock the file if needed, and write contents
         if unlock:
-            ds.unlock(outfile)
+            yield from ds.unlock(
+                outfile, result_renderer="disabled", return_type="generator"
+            )
         with open(outfile, "wt") as f:
             f.write(response)
 

--- a/datalad_redcap/tests/test_parameters.py
+++ b/datalad_redcap/tests/test_parameters.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 from datalad.api import export_redcap_form
 from datalad.distribution.dataset import Dataset
 
+from datalad_next.constraints import ConstraintError
 from datalad_next.utils import chpwd
 
 CSV_CONTENT = "foo,bar,baz\nspam,spam,spam"
@@ -24,7 +25,7 @@ def test_url_rejected(tmp_path, credman_filled, api_url):
     credname, _ = credman_filled.query(realm=api_url)[0]
     ds = Dataset(tmp_path).create(result_renderer="disabled")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ConstraintError):
         with patch(
             "datalad_redcap.export_form.Records.export_records",
             return_value=CSV_CONTENT,
@@ -42,7 +43,7 @@ def test_dataset_not_found(tmp_path, credman_filled, api_url):
     """Test that nonexistent dataset is rejected by validation"""
 
     # explicit path that isn't a dataset
-    with pytest.raises(ValueError):
+    with pytest.raises(ConstraintError):
         with patch(
             "datalad_redcap.export_form.Records.export_records",
             return_value=CSV_CONTENT,
@@ -56,7 +57,7 @@ def test_dataset_not_found(tmp_path, credman_filled, api_url):
 
     # no path given, pwd is not a dataset
     with chpwd(tmp_path, mkdir=True):
-        with pytest.raises(ValueError):
+        with pytest.raises(ConstraintError):
             with patch(
                 "datalad_redcap.export_form.Records.export_records",
                 return_value=CSV_CONTENT,

--- a/datalad_redcap/tests/test_query.py
+++ b/datalad_redcap/tests/test_query.py
@@ -3,14 +3,14 @@ from unittest.mock import patch
 from datalad.api import redcap_query
 from datalad_next.tests.utils import (
     assert_result_count,
-    with_credential,
 )
 
 JSON_CONTENT = {"foo": "bar"}
 
 
 def test_redcap_query_has_result(credman_filled, api_url):
-    with patch("datalad_redcap.query.MyInstruments.export_instruments", return_value=JSON_CONTENT):
-        assert_result_count(
-            redcap_query(url=api_url, result_renderer="disabled"), 1
-        )
+    with patch(
+        "datalad_redcap.query.MyInstruments.export_instruments",
+        return_value=JSON_CONTENT,
+    ):
+        assert_result_count(redcap_query(url=api_url, result_renderer="disabled"), 1)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -116,7 +116,7 @@ pygments_style = 'sphinx'
 todo_include_todos = True
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,8 @@ project_urls =
 [options]
 python_requires = >= 3.8
 install_requires =
-    datalad >= 0.18.1
-    datalad-next @ git+https://github.com/datalad/datalad-next.git@main
+    datalad >= 0.18.2
+    datalad-next >= 1.0.0b2
     pycap >= 2.3.0
     prettytable >= 3.6
 packages = find_namespace:


### PR DESCRIPTION
This PR sets a "proper" versioned dependency for `datalad-next >= 1.0.0b2` (replacing previous dependency on GitHub main) in anticipation of the redcap extension release. Closes #19

The PR includes adjustments of parameter validation to benefit from the new features added between beta1 and beta2 pre-releases of -next (`validate_defaults`, `tailor_for_dataset`).