### PR TITLE
Add a workaround for theme issues (search & read the docs menu)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,6 +71,7 @@ extensions = [
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
+    'sphinxcontrib.jquery',
 ]
 
 # for the module reference


### PR DESCRIPTION
This is a recommended workaround for search and flyout menu not
working with a combination of sphinx-6.2.1 & sphinx-rtd-theme-1.2.0.

There is no additional dependency to install, since the theme already
installs it. It will most likely be fixed with sphinx-rtd-theme v1.3,
at which point the commit can be reverted.

See: https://github.com/readthedocs/sphinx_rtd_theme/issues/1452