### PR TITLE
Fix RTD build setup

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,3 +12,5 @@ python:
   install:
     - method: pip
       path: .
+      extra_requirements:
+        - docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,9 @@ devel =
     coverage
     sphinx
     sphinx_rtd_theme
+docs =
+    sphinx
+    sphinx_rtd_theme
 
 [options.entry_points]
 # 'datalad.extensions' is THE entrypoint inspected by the datalad API builders


### PR DESCRIPTION
This adds options.extras_require.docs to the setup.cfg (a remaining question is whether the two packages should be removed from devel group or kept in both) and makes use of this option in the .readthedocs.yaml to make sure the theme and its dependenceies get installed during RTD build.

The change is introduced with an expectation to remove the following build error on ReadTheDocs:

  Could not import extension sphinxcontrib.jquery (exception: No
  module named 'sphinxcontrib.jquery')

See the build failure in eg.
https://app.readthedocs.org/projects/datalad-redcap/builds/28000704/